### PR TITLE
This commit fixes a bug that made sendmsg not work with multiple iovecs.

### DIFF
--- a/af_ktls.c
+++ b/af_ktls.c
@@ -212,7 +212,7 @@ struct tls_sock {
 	char aad_send[KTLS_AAD_SPACE_SIZE];
 	char tag_send[KTLS_TAG_SIZE];
 	struct page *pages_send;
-	struct af_alg_sgl sgl_send;
+	struct af_alg_sgl sgl_send[UIO_MAXIOV];
 	struct scatterlist sgaad_send[2];
 	struct scatterlist sgtag_send[2];
 
@@ -850,9 +850,10 @@ static int tls_do_encryption(struct tls_sock *tsk,
 
 static int tls_sendmsg(struct socket *sock, struct msghdr *msg, size_t size)
 {
-	int ret;
 	struct tls_sock *tsk;
-
+	unsigned int i;
+	unsigned int cnt = 0;
+	int ret = 0;
 	xprintk("--> %s", __FUNCTION__);
 
 	tsk = tls_sk(sock->sk);
@@ -872,15 +873,22 @@ static int tls_sendmsg(struct socket *sock, struct msghdr *msg, size_t size)
 
 	tls_make_aad(tsk, 0, tsk->aad_send, size, tsk->iv_send);
 
-	ret = af_alg_make_sg(&tsk->sgl_send, &msg->msg_iter, size);
-	if (ret < 0)
-		goto send_end;
-
+	while (iov_iter_count(&msg->msg_iter)) {
+		size_t seglen = iov_iter_count(&msg->msg_iter);
+		int len = af_alg_make_sg(&tsk->sgl_send[cnt], &msg->msg_iter, seglen);
+		if (len < 0)
+			goto send_end;
+		ret += len;
+		if (cnt)
+			af_alg_link_sg(&tsk->sgl_send[cnt-1], &tsk->sgl_send[cnt]);
+		iov_iter_advance(&msg->msg_iter, len);
+		cnt++;
+	}
 	sg_unmark_end(&tsk->sgaad_send[1]);
-	sg_chain(tsk->sgaad_send, 2, tsk->sgl_send.sg);
+	sg_chain(tsk->sgaad_send, 2, tsk->sgl_send[0].sg);
 
-	sg_unmark_end(tsk->sgl_send.sg + tsk->sgl_send.npages - 1);
-	sg_chain(tsk->sgl_send.sg, tsk->sgl_send.npages + 1, tsk->sgtag_send);
+	sg_unmark_end(tsk->sgl_send[cnt-1].sg + tsk->sgl_send[cnt-1].npages - 1);
+	sg_chain(tsk->sgl_send[cnt-1].sg, tsk->sgl_send[cnt-1].npages + 1, tsk->sgtag_send);
 
 	ret = tls_do_encryption(tsk, tsk->sgaad_send, tsk->sg_tx_data, size);
 	if (ret < 0)
@@ -897,6 +905,8 @@ static int tls_sendmsg(struct socket *sock, struct msghdr *msg, size_t size)
 	}
 
 send_end:
+	for (i = 0; i < cnt; i++)
+		af_alg_free_sg(&tsk->sgl_send[i]);
 	release_sock(sock->sk);
 	return ret;
 }
@@ -1372,7 +1382,7 @@ static ssize_t tls_do_sendpage(struct tls_sock *tsk)
 
 do_sendmsg_end:
 	// restore, so we can use sendmsg()
-	sg_chain(tsk->sgaad_send, 2, tsk->sgl_send.sg);
+	sg_chain(tsk->sgaad_send, 2, tsk->sgl_send[0].sg);
 	// remove chaining to sg tag
 	sg_mark_end(&tsk->sendpage_ctx.sg[tsk->sendpage_ctx.used]);
 
@@ -1715,7 +1725,8 @@ static int tls_create(struct net *net,
 		tsk->vec_send[i].iov_len = tsk->sg_tx_data[i].length;
 	}
 
-	memset(&tsk->sgl_send, 0, sizeof(tsk->sgl_send));
+	for (i = 0; i < UIO_MAXIOV; i++)
+		memset(&tsk->sgl_send[i], 0, sizeof(tsk->sgl_send[i]));
 	sg_init_table(tsk->sgaad_send, 2);
 	sg_init_table(tsk->sgtag_send, 2);
 
@@ -1724,7 +1735,7 @@ static int tls_create(struct net *net,
 	sg_set_buf(&tsk->sgtag_send[0], tsk->tag_send, sizeof(tsk->tag_send));
 
 	sg_unmark_end(&tsk->sgaad_send[1]);
-	sg_chain(tsk->sgaad_send, 2, tsk->sgl_send.sg);
+	sg_chain(tsk->sgaad_send, 2, tsk->sgl_send[0].sg);
 
 	/*
 	 * Preallocation for receiving


### PR DESCRIPTION
The bug was that af_alg_make_sg only builds the sgl from a single iovec,
where msg->msg_iter is an iterable over the iovecs. Therefore it needs
to be called in a loop and created multiple times with iov_iter_advance
used on msg->msg_iter. tsk->sgl_send needs to be changed to be an array
with the same size as the max number of iovecs