### PR TITLE
updated rfc5288 patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,20 +12,14 @@ OpenSSL or Gnu TLS.  ```AF_KTLS``` socket appears to be faster especially for
 transmitting files without user space (buffered-copy) interaction (using
 ```sendfile(2)``` or ```splice(2)```).
 
-The socket uses [RFC5288
-implementation](http://thread.gmane.org/gmane.linux.kernel/2091838) proposed on
-Linux crypto mailing list by Dave Watson from Facebook. Changes made by this
-patch were not merged, so you need to apply this patch in order to test
-```AF_KTLS``` socket implementation. If you want to look at benchmarking
-scenarios or test your use case speed impact, visit [AF_KTLS
+The socket uses RFC5288 proposed on Linux crypto mailing list by Dave
+Watson from Facebook. The latest patches for rfc5288 are included in
+this repo.  If you want to look at benchmarking scenarios or test your
+use case speed impact, visit [AF_KTLS
 tool](https://github.com/fridex/af_ktls-tool).
-
-You can find precompiled kernel for Fedora 23 with RFC 5288 patch applied
-[here](http://209.132.179.123:5000/).
 
 See [issues](http://github.com/fridex/af_ktls/issues) for awaiting
 enhancements or bugs.
 
 See also [AF_KTLS tool](https://github.com/fridex/af_ktls-tool), [AF_KTLS
 visualize](https://github.com/fridex/af_ktls-visualize).
-

--- a/af_ktls.c
+++ b/af_ktls.c
@@ -50,11 +50,7 @@
 /* +1 for aad, +1 for tag, +1 for chaining */
 #define KTLS_SG_DATA_SIZE		(KTLS_DATA_PAGES + 3)
 
-/* RFC5288 patch requires 24 bytes allocated
- */
-#define KTLS_AAD_SPACE_SIZE		24
-/* RFC52888: AAD is zero-padded to 21 */
-#define KTLS_PADDED_AAD_SIZE		21
+#define KTLS_AAD_SPACE_SIZE		21
 #define KTLS_AAD_SIZE			13
 
 /* TLS
@@ -983,9 +979,6 @@ static inline void tls_make_aad(struct tls_sock *tsk,
 				size_t size,
 				char *nonce_explicit)
 {
-	/* has to be zero padded according to RFC5288 */
-	memset(buf, 0, KTLS_AAD_SPACE_SIZE);
-
 	memcpy(buf, nonce_explicit, KTLS_NONCE_SIZE);
 
 	buf[8] = KTLS_RECORD_DATA;
@@ -1009,7 +1002,7 @@ static int tls_do_encryption(struct tls_sock *tsk,
 		return -ENOMEM;
 
 	aead_request_set_tfm(aead_req, tsk->aead_send);
-	aead_request_set_ad(aead_req, KTLS_PADDED_AAD_SIZE);
+	aead_request_set_ad(aead_req, KTLS_AAD_SPACE_SIZE);
 	aead_request_set_crypt(aead_req, sgin, sgout, data_len, tsk->iv_send);
 	aead_request_set_callback(aead_req, 0, NULL, NULL);
 
@@ -1281,7 +1274,7 @@ static int tls_do_decryption(struct tls_sock *tsk,
 		return -ENOMEM;
 
 	aead_request_set_tfm(aead_req, tsk->aead_recv);
-	aead_request_set_ad(aead_req, KTLS_PADDED_AAD_SIZE);
+	aead_request_set_ad(aead_req, KTLS_AAD_SPACE_SIZE);
 	aead_request_set_crypt(aead_req, sgin, sgout,
 			       data_len + KTLS_TAG_SIZE,
 			       (u8 *)header_recv + KTLS_NONCE_OFFSET(tsk));

--- a/rfc5288-aesni.patch
+++ b/rfc5288-aesni.patch
@@ -1,0 +1,249 @@
+diff --git a/arch/x86/crypto/aesni-intel_asm.S b/arch/x86/crypto/aesni-intel_asm.S
+index 383a6f8..4e80bb8 100644
+--- a/arch/x86/crypto/aesni-intel_asm.S
++++ b/arch/x86/crypto/aesni-intel_asm.S
+@@ -229,6 +229,9 @@ XMM2 XMM3 XMM4 XMMDst TMP6 TMP7 i i_seq operation
+         MOVADQ     SHUF_MASK(%rip), %xmm14
+ 	mov	   arg7, %r10           # %r10 = AAD
+ 	mov	   arg8, %r12           # %r12 = aadLen
++	add        $3, %r12
++	and        $~3, %r12
++
+ 	mov	   %r12, %r11
+ 	pxor	   %xmm\i, %xmm\i
+ 
+@@ -454,6 +457,9 @@ XMM2 XMM3 XMM4 XMMDst TMP6 TMP7 i i_seq operation
+         MOVADQ     SHUF_MASK(%rip), %xmm14
+ 	mov	   arg7, %r10           # %r10 = AAD
+ 	mov	   arg8, %r12           # %r12 = aadLen
++	add        $3, %r12
++	and        $~3, %r12
++
+ 	mov	   %r12, %r11
+ 	pxor	   %xmm\i, %xmm\i
+ _get_AAD_loop\num_initial_blocks\operation:
+diff --git a/arch/x86/crypto/aesni-intel_avx-x86_64.S b/arch/x86/crypto/aesni-intel_avx-x86_64.S
+index 522ab68..0756e4a 100644
+--- a/arch/x86/crypto/aesni-intel_avx-x86_64.S
++++ b/arch/x86/crypto/aesni-intel_avx-x86_64.S
+@@ -360,6 +360,8 @@ VARIABLE_OFFSET = 16*8
+ 
+         mov     arg6, %r10                      # r10 = AAD
+         mov     arg7, %r12                      # r12 = aadLen
++        add     $3, %r12
++        and     $~3, %r12
+ 
+ 
+         mov     %r12, %r11
+@@ -1619,6 +1621,8 @@ ENDPROC(aesni_gcm_dec_avx_gen2)
+ 
+         mov     arg6, %r10                       # r10 = AAD
+         mov     arg7, %r12                       # r12 = aadLen
++        add     $3, %r12
++        and     $~3, %r12
+ 
+ 
+         mov     %r12, %r11
+diff --git a/arch/x86/crypto/aesni-intel_glue.c b/arch/x86/crypto/aesni-intel_glue.c
+index 0ab5ee1..b1ab0cb 100644
+--- a/arch/x86/crypto/aesni-intel_glue.c
++++ b/arch/x86/crypto/aesni-intel_glue.c
+@@ -881,6 +881,8 @@ static int helper_rfc4106_encrypt(struct aead_request *req)
+ {
+ 	u8 one_entry_in_sg = 0;
+ 	u8 *src, *dst, *assoc;
++	u8 *assocmem = NULL;
++
+ 	__be32 counter = cpu_to_be32(1);
+ 	struct crypto_aead *tfm = crypto_aead_reqtfm(req);
+ 	struct aesni_rfc4106_gcm_ctx *ctx = aesni_rfc4106_gcm_ctx_get(tfm);
+@@ -890,12 +892,8 @@ static int helper_rfc4106_encrypt(struct aead_request *req)
+ 	struct scatter_walk src_sg_walk;
+ 	struct scatter_walk dst_sg_walk;
+ 	unsigned int i;
+-
+-	/* Assuming we are supporting rfc4106 64-bit extended */
+-	/* sequence numbers We need to have the AAD length equal */
+-	/* to 16 or 20 bytes */
+-	if (unlikely(req->assoclen != 16 && req->assoclen != 20))
+-		return -EINVAL;
++	unsigned int padded_assoclen = (req->assoclen + 3) & ~3;
++	u8 assocbuf[24];
+ 
+ 	/* IV below built */
+ 	for (i = 0; i < 4; i++)
+@@ -920,7 +918,8 @@ static int helper_rfc4106_encrypt(struct aead_request *req)
+ 	} else {
+ 		/* Allocate memory for src, dst, assoc */
+ 		assoc = kmalloc(req->cryptlen + auth_tag_len + req->assoclen,
+-			GFP_ATOMIC);
++				GFP_ATOMIC);
++		assocmem = assoc;
+ 		if (unlikely(!assoc))
+ 			return -ENOMEM;
+ 		scatterwalk_map_and_copy(assoc, req->src, 0,
+@@ -929,6 +928,14 @@ static int helper_rfc4106_encrypt(struct aead_request *req)
+ 		dst = src;
+ 	}
+ 
++	if (req->assoclen != padded_assoclen) {
++		scatterwalk_map_and_copy(assocbuf, req->src, 0,
++					 req->assoclen, 0);
++		memset(assocbuf + req->assoclen, 0,
++		       padded_assoclen - req->assoclen);
++		assoc = assocbuf;
++	}
++
+ 	kernel_fpu_begin();
+ 	aesni_gcm_enc_tfm(aes_ctx, dst, src, req->cryptlen, iv,
+ 			  ctx->hash_subkey, assoc, req->assoclen - 8,
+@@ -949,7 +956,7 @@ static int helper_rfc4106_encrypt(struct aead_request *req)
+ 	} else {
+ 		scatterwalk_map_and_copy(dst, req->dst, req->assoclen,
+ 					 req->cryptlen + auth_tag_len, 1);
+-		kfree(assoc);
++		kfree(assocmem);
+ 	}
+ 	return 0;
+ }
+@@ -958,6 +965,7 @@ static int helper_rfc4106_decrypt(struct aead_request *req)
+ {
+ 	u8 one_entry_in_sg = 0;
+ 	u8 *src, *dst, *assoc;
++	u8 *assocmem = NULL;
+ 	unsigned long tempCipherLen = 0;
+ 	__be32 counter = cpu_to_be32(1);
+ 	int retval = 0;
+@@ -967,16 +975,11 @@ static int helper_rfc4106_decrypt(struct aead_request *req)
+ 	unsigned long auth_tag_len = crypto_aead_authsize(tfm);
+ 	u8 iv[16] __attribute__ ((__aligned__(AESNI_ALIGN)));
+ 	u8 authTag[16];
++	u8 assocbuf[24];
+ 	struct scatter_walk src_sg_walk;
+ 	struct scatter_walk dst_sg_walk;
+ 	unsigned int i;
+-
+-	if (unlikely(req->assoclen != 16 && req->assoclen != 20))
+-		return -EINVAL;
+-
+-	/* Assuming we are supporting rfc4106 64-bit extended */
+-	/* sequence numbers We need to have the AAD length */
+-	/* equal to 16 or 20 bytes */
++	unsigned int padded_assoclen = (req->assoclen + 3) & ~3;
+ 
+ 	tempCipherLen = (unsigned long)(req->cryptlen - auth_tag_len);
+ 	/* IV below built */
+@@ -1003,6 +1006,7 @@ static int helper_rfc4106_decrypt(struct aead_request *req)
+ 	} else {
+ 		/* Allocate memory for src, dst, assoc */
+ 		assoc = kmalloc(req->cryptlen + req->assoclen, GFP_ATOMIC);
++		assocmem = assoc;
+ 		if (!assoc)
+ 			return -ENOMEM;
+ 		scatterwalk_map_and_copy(assoc, req->src, 0,
+@@ -1011,6 +1015,14 @@ static int helper_rfc4106_decrypt(struct aead_request *req)
+ 		dst = src;
+ 	}
+ 
++	if (req->assoclen != padded_assoclen) {
++		scatterwalk_map_and_copy(assocbuf, req->src,
++					 0, req->assoclen, 0);
++		memset(assocbuf + req->assoclen, 0,
++		       padded_assoclen - req->assoclen);
++		assoc = assocbuf;
++	}
++
+ 	kernel_fpu_begin();
+ 	aesni_gcm_dec_tfm(aes_ctx, dst, src, tempCipherLen, iv,
+ 			  ctx->hash_subkey, assoc, req->assoclen - 8,
+@@ -1033,7 +1045,7 @@ static int helper_rfc4106_decrypt(struct aead_request *req)
+ 	} else {
+ 		scatterwalk_map_and_copy(dst, req->dst, req->assoclen,
+ 					 tempCipherLen, 1);
+-		kfree(assoc);
++		kfree(assocmem);
+ 	}
+ 	return retval;
+ }
+@@ -1051,6 +1063,12 @@ static int rfc4106_encrypt(struct aead_request *req)
+ 
+ 	aead_request_set_tfm(req, tfm);
+ 
++	/* Assuming we are supporting rfc4106 64-bit extended */
++	/* sequence numbers We need to have the AAD length */
++	/* equal to 16 or 20 bytes */
++	if (unlikely(req->assoclen != 16 && req->assoclen != 20))
++		return -EINVAL;
++
+ 	return crypto_aead_encrypt(req);
+ }
+ 
+@@ -1067,6 +1085,43 @@ static int rfc4106_decrypt(struct aead_request *req)
+ 
+ 	aead_request_set_tfm(req, tfm);
+ 
++	/* Assuming we are supporting rfc4106 64-bit extended */
++	/* sequence numbers We need to have the AAD length */
++	/* equal to 16 or 20 bytes */
++	if (unlikely(req->assoclen != 16 && req->assoclen != 20))
++		return -EINVAL;
++
++	return crypto_aead_decrypt(req);
++}
++
++static int rfc5288_encrypt(struct aead_request *req)
++{
++	struct crypto_aead *tfm = crypto_aead_reqtfm(req);
++	struct cryptd_aead **ctx = crypto_aead_ctx(tfm);
++	struct cryptd_aead *cryptd_tfm = *ctx;
++
++	if (unlikely(req->assoclen != 21))
++		return -EINVAL;
++
++	aead_request_set_tfm(req, irq_fpu_usable() ?
++				  cryptd_aead_child(cryptd_tfm) :
++				  &cryptd_tfm->base);
++
++	return crypto_aead_encrypt(req);
++}
++
++static int rfc5288_decrypt(struct aead_request *req)
++{
++	struct crypto_aead *tfm = crypto_aead_reqtfm(req);
++	struct cryptd_aead **ctx = crypto_aead_ctx(tfm);
++	struct cryptd_aead *cryptd_tfm = *ctx;
++
++	if (unlikely(req->assoclen != 21))
++		return -EINVAL;
++
++	aead_request_set_tfm(req, irq_fpu_usable() ?
++				  cryptd_aead_child(cryptd_tfm) :
++				  &cryptd_tfm->base);
+ 	return crypto_aead_decrypt(req);
+ }
+ #endif
+@@ -1389,6 +1444,24 @@ static struct aead_alg aesni_aead_algs[] = { {
+ 		.cra_ctxsize		= sizeof(struct cryptd_aead *),
+ 		.cra_module		= THIS_MODULE,
+ 	},
++}, {
++	.init			= rfc4106_init,
++	.exit			= rfc4106_exit,
++	.setkey			= rfc4106_set_key,
++	.setauthsize		= rfc4106_set_authsize,
++	.encrypt		= rfc5288_encrypt,
++	.decrypt		= rfc5288_decrypt,
++	.ivsize			= 8,
++	.maxauthsize		= 16,
++	.base = {
++		.cra_name		= "rfc5288(gcm(aes))",
++		.cra_driver_name	= "rfc5288-gcm-aesni",
++		.cra_priority		= 400,
++		.cra_flags		= CRYPTO_ALG_ASYNC,
++		.cra_blocksize		= 1,
++		.cra_ctxsize		= sizeof(struct cryptd_aead *),
++		.cra_module		= THIS_MODULE,
++	},
+ } };
+ #else
+ static struct aead_alg aesni_aead_algs[0];

--- a/rfc5288.patch
+++ b/rfc5288.patch
@@ -1,0 +1,293 @@
+diff --git a/crypto/gcm.c b/crypto/gcm.c
+index 70a892e8..84598c1 100644
+--- a/crypto/gcm.c
++++ b/crypto/gcm.c
+@@ -1016,6 +1016,120 @@ static struct crypto_template crypto_rfc4106_tmpl = {
+ 	.module = THIS_MODULE,
+ };
+ 
++static int crypto_rfc5288_encrypt(struct aead_request *req)
++{
++	if (req->assoclen != 21)
++		return -EINVAL;
++
++	req = crypto_rfc4106_crypt(req);
++
++	return crypto_aead_encrypt(req);
++}
++
++static int crypto_rfc5288_decrypt(struct aead_request *req)
++{
++	if (req->assoclen != 21)
++		return -EINVAL;
++
++	req = crypto_rfc4106_crypt(req);
++
++	return crypto_aead_decrypt(req);
++}
++
++static int crypto_rfc5288_create(struct crypto_template *tmpl,
++				 struct rtattr **tb)
++{
++	struct crypto_attr_type *algt;
++	struct aead_instance *inst;
++	struct crypto_aead_spawn *spawn;
++	struct aead_alg *alg;
++	const char *ccm_name;
++	int err;
++
++	algt = crypto_get_attr_type(tb);
++	if (IS_ERR(algt))
++		return PTR_ERR(algt);
++
++	if ((algt->type ^ CRYPTO_ALG_TYPE_AEAD) & algt->mask)
++		return -EINVAL;
++
++	ccm_name = crypto_attr_alg_name(tb[1]);
++	if (IS_ERR(ccm_name))
++		return PTR_ERR(ccm_name);
++
++	inst = kzalloc(sizeof(*inst) + sizeof(*spawn), GFP_KERNEL);
++	if (!inst)
++		return -ENOMEM;
++
++	spawn = aead_instance_ctx(inst);
++	crypto_set_aead_spawn(spawn, aead_crypto_instance(inst));
++	err = crypto_grab_aead(spawn, ccm_name, 0,
++			       crypto_requires_sync(algt->type, algt->mask));
++	if (err)
++		goto out_free_inst;
++
++	alg = crypto_spawn_aead_alg(spawn);
++
++	err = -EINVAL;
++
++	/* Underlying IV size must be 12. */
++	if (crypto_aead_alg_ivsize(alg) != 12)
++		goto out_drop_alg;
++
++	/* Not a stream cipher? */
++	if (alg->base.cra_blocksize != 1)
++		goto out_drop_alg;
++
++	err = -ENAMETOOLONG;
++	if (snprintf(inst->alg.base.cra_name, CRYPTO_MAX_ALG_NAME,
++		     "rfc5288(%s)", alg->base.cra_name) >=
++	    CRYPTO_MAX_ALG_NAME ||
++	    snprintf(inst->alg.base.cra_driver_name, CRYPTO_MAX_ALG_NAME,
++		     "rfc5288(%s)", alg->base.cra_driver_name) >=
++	    CRYPTO_MAX_ALG_NAME)
++		goto out_drop_alg;
++
++	inst->alg.base.cra_flags = alg->base.cra_flags & CRYPTO_ALG_ASYNC;
++	inst->alg.base.cra_priority = alg->base.cra_priority;
++	inst->alg.base.cra_blocksize = 1;
++	inst->alg.base.cra_alignmask = alg->base.cra_alignmask;
++
++	inst->alg.base.cra_ctxsize = sizeof(struct crypto_rfc4106_ctx);
++
++	inst->alg.ivsize = 8;
++	inst->alg.chunksize = crypto_aead_alg_chunksize(alg);
++	inst->alg.maxauthsize = crypto_aead_alg_maxauthsize(alg);
++
++	inst->alg.init = crypto_rfc4106_init_tfm;
++	inst->alg.exit = crypto_rfc4106_exit_tfm;
++
++	inst->alg.setkey = crypto_rfc4106_setkey;
++	inst->alg.setauthsize = crypto_rfc4106_setauthsize;
++	inst->alg.encrypt = crypto_rfc5288_encrypt;
++	inst->alg.decrypt = crypto_rfc5288_decrypt;
++
++	inst->free = crypto_rfc4106_free;
++
++	err = aead_register_instance(tmpl, inst);
++	if (err)
++		goto out_drop_alg;
++
++out:
++	return err;
++
++out_drop_alg:
++	crypto_drop_aead(spawn);
++out_free_inst:
++	kfree(inst);
++	goto out;
++}
++
++static struct crypto_template crypto_rfc5288_tmpl = {
++	.name = "rfc5288",
++	.create = crypto_rfc5288_create,
++	.module = THIS_MODULE,
++};
++
+ static int crypto_rfc4543_setkey(struct crypto_aead *parent, const u8 *key,
+ 				 unsigned int keylen)
+ {
+@@ -1284,8 +1398,14 @@ static int __init crypto_gcm_module_init(void)
+ 	if (err)
+ 		goto out_undo_rfc4106;
+ 
++	err = crypto_register_template(&crypto_rfc5288_tmpl);
++	if (err)
++		goto out_undo_rfc4543;
++
+ 	return 0;
+ 
++out_undo_rfc4543:
++	crypto_unregister_template(&crypto_rfc4543_tmpl);
+ out_undo_rfc4106:
+ 	crypto_unregister_template(&crypto_rfc4106_tmpl);
+ out_undo_gcm:
+@@ -1302,6 +1422,7 @@ static void __exit crypto_gcm_module_exit(void)
+ 	kfree(gcm_zeroes);
+ 	crypto_unregister_template(&crypto_rfc4543_tmpl);
+ 	crypto_unregister_template(&crypto_rfc4106_tmpl);
++	crypto_unregister_template(&crypto_rfc5288_tmpl);
+ 	crypto_unregister_template(&crypto_gcm_tmpl);
+ 	crypto_unregister_template(&crypto_gcm_base_tmpl);
+ }
+@@ -1315,4 +1436,5 @@ MODULE_AUTHOR("Mikko Herranen <mh1@iki.fi>");
+ MODULE_ALIAS_CRYPTO("gcm_base");
+ MODULE_ALIAS_CRYPTO("rfc4106");
+ MODULE_ALIAS_CRYPTO("rfc4543");
++MODULE_ALIAS_CRYPTO("rfc5288");
+ MODULE_ALIAS_CRYPTO("gcm");
+diff --git a/crypto/tcrypt.c b/crypto/tcrypt.c
+index ae22f05..22538a7 100644
+--- a/crypto/tcrypt.c
++++ b/crypto/tcrypt.c
+@@ -1338,26 +1338,30 @@ static int do_test(const char *alg, u32 type, u32 mask, int m)
+ 		break;
+ 
+ 	case 152:
+-		ret += tcrypt_test("rfc4543(gcm(aes))");
++		ret += tcrypt_test("rfc5288(gcm(aes))");
+ 		break;
+ 
+ 	case 153:
+-		ret += tcrypt_test("cmac(aes)");
++		ret += tcrypt_test("rfc4543(gcm(aes))");
+ 		break;
+ 
+ 	case 154:
+-		ret += tcrypt_test("cmac(des3_ede)");
++		ret += tcrypt_test("cmac(aes)");
+ 		break;
+ 
+ 	case 155:
+-		ret += tcrypt_test("authenc(hmac(sha1),cbc(aes))");
++		ret += tcrypt_test("cmac(des3_ede)");
+ 		break;
+ 
+ 	case 156:
+-		ret += tcrypt_test("authenc(hmac(md5),ecb(cipher_null))");
++		ret += tcrypt_test("authenc(hmac(sha1),cbc(aes))");
+ 		break;
+ 
+ 	case 157:
++		ret += tcrypt_test("authenc(hmac(md5),ecb(cipher_null))");
++		break;
++
++	case 158:
+ 		ret += tcrypt_test("authenc(hmac(sha1),ecb(cipher_null))");
+ 		break;
+ 	case 181:
+diff --git a/crypto/testmgr.c b/crypto/testmgr.c
+index 5c9d5a5..e1960ea 100644
+--- a/crypto/testmgr.c
++++ b/crypto/testmgr.c
+@@ -3736,6 +3736,22 @@ static const struct alg_test_desc alg_test_descs[] = {
+ 			}
+ 		}
+ 	}, {
++		.alg = "rfc5288(gcm(aes))",
++		.test = alg_test_aead,
++		.fips_allowed = 1,
++		.suite = {
++			.aead = {
++				.enc = {
++					.vecs = aes_gcm_rfc5288_enc_tv_template,
++					.count = AES_GCM_5288_ENC_TEST_VECTORS
++				},
++				.dec = {
++					.vecs = aes_gcm_rfc5288_dec_tv_template,
++					.count = AES_GCM_5288_DEC_TEST_VECTORS
++				}
++			}
++		}
++	}, {
+ 		.alg = "rfc7539(chacha20,poly1305)",
+ 		.test = alg_test_aead,
+ 		.suite = {
+diff --git a/crypto/testmgr.h b/crypto/testmgr.h
+index acb6bbf..3b6ab4a 100644
+--- a/crypto/testmgr.h
++++ b/crypto/testmgr.h
+@@ -15191,6 +15191,8 @@ static struct cipher_testvec cast6_xts_dec_tv_template[] = {
+ #define AES_GCM_DEC_TEST_VECTORS 8
+ #define AES_GCM_4106_ENC_TEST_VECTORS 23
+ #define AES_GCM_4106_DEC_TEST_VECTORS 23
++#define AES_GCM_5288_ENC_TEST_VECTORS 1
++#define AES_GCM_5288_DEC_TEST_VECTORS 1
+ #define AES_GCM_4543_ENC_TEST_VECTORS 1
+ #define AES_GCM_4543_DEC_TEST_VECTORS 2
+ #define AES_CCM_ENC_TEST_VECTORS 8
+@@ -21928,6 +21930,7 @@ static struct aead_testvec aes_gcm_rfc4106_dec_tv_template[] = {
+ 		.assoc  = "\x01\x01\x01\x01\x01\x01\x01\x01"
+ 			  "\x00\x00\x00\x00\x00\x00\x00\x00",
+ 		.alen   = 16,
++
+ 		.result = "\x01\x01\x01\x01\x01\x01\x01\x01"
+ 			  "\x01\x01\x01\x01\x01\x01\x01\x01",
+ 		.rlen   = 16,
+@@ -22481,6 +22484,50 @@ static struct aead_testvec aes_gcm_rfc4106_dec_tv_template[] = {
+ 	}
+ };
+ 
++static struct aead_testvec aes_gcm_rfc5288_enc_tv_template[] = {
++	{
++		.key	= "\x34\x19\x96\x6e\xc5\x8c\x17\x9c"
++			  "\x56\x78\x5e\xbb\x30\x52\x21\x89"
++			  "\xea\xbc\x6e\x50",
++		.klen	= 20,
++		.iv	= "\x00\x00\x00\x00\x00\x00\x00\x01"
++			  "\x5f\x73\x65\x73",
++		.assoc	= "\x00\x00\x00\x00\x00\x00\x00\x01"
++			  "\x17\x03\x03\x00\x10\x00\x00\x00"
++			  "\x00\x00\x00\x00\x00",
++		.alen	= 21,
++		.input	= zeroed_string,
++		.ilen	= 16,
++		.result	= "\xa5\x2b\x6c\x6e\x2d\x78\x6f\x80"
++			  "\x0e\x65\x69\x70\x0a\xe8\x86\xed"
++			  "\x6d\x38\x29\x1d\x35\x3f\x62\xcf"
++			  "\x46\x9c\x19\x78\x00\x0d\x67\xaa",
++		.rlen	= 32,
++	}
++};
++
++static struct aead_testvec aes_gcm_rfc5288_dec_tv_template[] = {
++	{
++		.key	= "\x73\xf0\xfa\x44\x76\xf5\xd5\x17"
++			  "\x00\x12\x42\x85\xcb\x4f\x92\x1f"
++			  "\x7d\x63\x9f\xc6",
++		.klen	= 20,
++		.iv	= "\x00\x00\x00\x00\x00\x00\x00\x01"
++			  "\x74\x61\x73\x6b",
++		.assoc	= "\x00\x00\x00\x00\x00\x00\x00\x01"
++			  "\x17\x03\x03\x00\x10\x00\x00\x00"
++			  "\x00\x00\x00\x00\x00",
++		.alen	= 21,
++		.input	= "\x05\x56\x46\x23\x1c\x86\x5e\xd0"
++			  "\x12\x37\x2a\xa3\x65\x8b\x8c\x90"
++			  "\xab\xbd\xca\xda\xae\x6e\xc0\xb2"
++			  "\x91\x1b\x9b\x34\xe3\xea\x86\x8f",
++		.ilen	= 32,
++		.result	= zeroed_string,
++		.rlen	= 16,
++	},
++};
++
+ static struct aead_testvec aes_gcm_rfc4543_enc_tv_template[] = {
+ 	{ /* From draft-mcgrew-gcm-test-01 */
+ 		.key	= "\x4c\x80\xcd\xef\xbb\x5d\x10\xda"


### PR DESCRIPTION
This is an updated rfc5288 patchset.  It also implements the non-intel software routines, so it will work on any hardware.  Template to gcm.c code added as per request of linux crypto maintainer.

Padding in af_ktls is no longer necessary, the aesni driver will pad.