### PR TITLE
Kcmktls

### DIFF
--- a/af_ktls.c
+++ b/af_ktls.c
@@ -268,6 +268,8 @@ static void increment_seqno(unsigned char *seq, struct tls_sock *tsk)
 static void tls_unattach(struct tls_sock *tsk)
 {
 	write_lock_bh(&tsk->socket->sk->sk_callback_lock);
+	tsk->rx_stopped = 1;
+	strp_stop(&tsk->strp);
 	tsk->socket->sk->sk_data_ready = tsk->saved_sk_data_ready;
 	tsk->socket->sk->sk_write_space = tsk->saved_sk_write_space;
 	tsk->socket->sk->sk_user_data = NULL;
@@ -290,7 +292,8 @@ static void tls_abort_cb(struct strparser *strp, int err)
 	struct tls_sock *tsk;
 
 	tsk = strp->sk->sk_user_data;
-	tls_err_abort(tsk);
+	if (tsk)
+		tls_err_abort(tsk);
 }
 
 static int decrypt_skb(struct tls_sock *tsk, struct sk_buff *skb)
@@ -316,12 +319,6 @@ static int decrypt_skb(struct tls_sock *tsk, struct sk_buff *skb)
 	sg_init_table(tsk->sgin, ARRAY_SIZE(tsk->sgin));
 	sg_set_buf(&tsk->sgin[0], tsk->aad_recv, sizeof(tsk->aad_recv));
 
-	/* TODO: So what exactly happens if skb_to_sgvec causes more
-	 * than ALG_MAX_PAGES fragments? Consider allocating kernel
-	 * pages tls_read_size already copied headers and
-	 * aad. Therefore this simply needs to pass the encrypted data
-	 * + message
-	 */
 	nsg = skb_to_sgvec(skb, &tsk->sgin[1], rxm->offset +
 			prepend,
 			rxm->full_len - prepend);
@@ -449,7 +446,10 @@ static int tls_parse_cb(struct strparser *strp, struct sk_buff *skb)
 
 	tsk = strp->sk->sk_user_data;
 
-	return tls_read_size(tsk, skb);
+	if (tsk)
+		return tls_read_size(tsk, skb);
+	else
+		return -1;
 }
 
 static void tls_queue(struct strparser *strp, struct sk_buff *skb)
@@ -461,7 +461,13 @@ static void tls_queue(struct strparser *strp, struct sk_buff *skb)
 	rxm = strp_rx_msg(skb);
 	tsk = strp->sk->sk_user_data;
 
+	if (!tsk || tsk->rx_stopped) {
+		kfree_skb(skb);
+		return;
+	}
+
 	tls_rx_msg(skb)->decrypted = 0;
+	bh_lock_sock(&tsk->sk);
 
 	ret = sock_queue_rcv_skb((struct sock *)tsk, skb);
 	if (ret < 0) {
@@ -470,7 +476,9 @@ static void tls_queue(struct strparser *strp, struct sk_buff *skb)
 		 */
 		skb_queue_tail(&tsk->rx_hold_queue, skb);
 		strp->rx_paused = 1;
+		tsk->sk.sk_data_ready(&tsk->sk);
 	}
+	bh_unlock_sock(&tsk->sk);
 }
 
 /* Called with lower socket held */
@@ -1004,7 +1012,7 @@ static int tls_do_encryption(struct tls_sock *tsk,
 	unsigned int req_size = sizeof(struct aead_request) +
 		crypto_aead_reqsize(tsk->aead_recv);
 	struct aead_request *aead_req = (void *)sock_kmalloc(&tsk->sk, req_size,
-							GFP_KERNEL);
+							GFP_ATOMIC);
 	if (!aead_req)
 		return -ENOMEM;
 
@@ -1033,7 +1041,7 @@ static int tls_pre_encrypt(struct tls_sock *tsk, size_t data_len)
 	struct scatterlist *sg;
 	int ret = 0;
 
-	encrypt_len = data_len + KTLS_TAG_SIZE;
+	encrypt_len = data_len + KTLS_OVERHEAD(tsk);
 	npages = encrypt_len / PAGE_SIZE;
 	aligned_size = npages * PAGE_SIZE;
 	if (aligned_size < encrypt_len)
@@ -1170,13 +1178,12 @@ static int tls_sendmsg(struct socket *sock, struct msghdr *msg, size_t size)
 		if (sk->sk_err)
 			goto send_end;
 
+		if (!sk_stream_memory_free(sk))
+			goto wait_for_memory;
+
 		skb = tcp_write_queue_tail(sk);
 
 		while (!skb) {
-			ret = sk_stream_wait_memory(sk, &timeo);
-			if (ret)
-				goto send_end;
-
 			skb = alloc_skb(0, sk->sk_allocation);
 			if (skb)
 				__skb_queue_tail(&sk->sk_write_queue, skb);
@@ -1246,6 +1253,7 @@ static int tls_sendmsg(struct socket *sock, struct msghdr *msg, size_t size)
 
 wait_for_memory:
 		tls_push(tsk);
+		set_bit(SOCK_NOSPACE, &sk->sk_socket->flags);
 		ret = sk_stream_wait_memory(sk, &timeo);
 		if (ret)
 			goto send_end;
@@ -1276,7 +1284,7 @@ static int tls_do_decryption(struct tls_sock *tsk,
 	unsigned int req_size = sizeof(struct aead_request) +
 		crypto_aead_reqsize(tsk->aead_recv);
 	struct aead_request *aead_req = (void *)sock_kmalloc(&tsk->sk, req_size,
-							GFP_KERNEL);
+							GFP_ATOMIC);
 	if (!aead_req)
 		return -ENOMEM;
 
@@ -1375,7 +1383,7 @@ static void tls_dequeue_held_data(struct tls_sock *tsk)
 		int unpause = 1;
 		struct sk_buff *skb;
 
-		while ((skb = __skb_dequeue(&tsk->rx_hold_queue))) {
+		while ((skb = skb_dequeue(&tsk->rx_hold_queue))) {
 			int ret = sock_queue_rcv_skb((struct sock *)tsk, skb);
 
 			if (ret < 0) {
@@ -1479,9 +1487,9 @@ static int tls_recvmsg(struct socket *sock,
 		copied += chunk;
 		len -= chunk;
 		if (likely(!(flags & MSG_PEEK))) {
-			if (copied < rxm->full_len) {
-				rxm->offset += copied;
-				rxm->full_len -= copied;
+			if (chunk < rxm->full_len) {
+				rxm->offset += chunk;
+				rxm->full_len -= chunk;
 			} else {
 				/* Finished with message */
 				skb_unlink(skb, &((struct sock *)tsk)
@@ -1647,7 +1655,7 @@ static ssize_t tls_sendpage(struct socket *sock, struct page *page,
 	sk_clear_bit(SOCKWQ_ASYNC_NOSPACE, sk);
 
 	/* Call the sk_stream functions to manage the sndbuf mem. */
-	while (queued < size) {
+	while (size > 0) {
 		size_t send_size = min(size, KTLS_MAX_PAYLOAD_SIZE);
 
 		if (!sk_stream_memory_free(sk) ||
@@ -1687,6 +1695,8 @@ static ssize_t tls_sendpage(struct socket *sock, struct page *page,
 					ret = sk_stream_wait_memory(sk, &timeo);
 					if (ret)
 						goto sendpage_end;
+
+					tskb = alloc_skb(0, sk->sk_allocation);
 				}
 
 				if (skb)
@@ -1714,12 +1724,17 @@ coalesced:
 		sk->sk_wmem_queued += send_size;
 		sk_mem_charge(sk, send_size);
 		tsk->unsent += send_size;
+		queued += send_size;
+		offset += queued;
+		size -= send_size;
 
 		if (eor || tsk->unsent >= KTLS_MAX_PAYLOAD_SIZE)
 			tls_push(tsk);
-		queued += send_size;
 	}
 sendpage_end:
+	if (eor || tsk->unsent >= KTLS_MAX_PAYLOAD_SIZE)
+		tls_push(tsk);
+
 	ret = sk_stream_error(sk, flags, ret);
 
 	if (ret < 0)
@@ -1731,7 +1746,7 @@ sendpage_end:
 
 	release_sock(sk);
 
-	return ret < 0 ? ret : size;
+	return ret < 0 ? ret : queued;
 }
 
 static int tls_bind(struct socket *sock, struct sockaddr *uaddr, int addr_len)
@@ -1784,7 +1799,7 @@ static int tls_bind(struct socket *sock, struct sockaddr *uaddr, int addr_len)
 	tsk->socket = sockfd_lookup(sa_ktls->sa_socket, &ret);
 	if (!tsk->socket) {
 		ret = -ENOENT;
-		goto bind_end;
+		goto out;
 	}
 	if (!IS_TCP(tsk->socket) && !IS_UDP(tsk->socket)) {
 		ret = -EAFNOSUPPORT;
@@ -1920,24 +1935,25 @@ static void tls_sock_destruct(struct sock *sk)
 
 	tsk = tls_sk(sk);
 
-	cancel_work_sync(&tsk->recv_work);
-	cancel_work_sync(&tsk->send_work);
-
-	skb_queue_purge(&tsk->rx_hold_queue);
-
 	/* restore callback and abandon socket */
 	if (tsk->socket) {
 		write_lock_bh(&tsk->socket->sk->sk_callback_lock);
 
 		tsk->rx_stopped = 1;
+		strp_stop(&tsk->strp);
 		tsk->socket->sk->sk_data_ready = tsk->saved_sk_data_ready;
 		tsk->socket->sk->sk_write_space = tsk->saved_sk_write_space;
 		tsk->socket->sk->sk_user_data = NULL;
 		write_unlock_bh(&tsk->socket->sk->sk_callback_lock);
 
+		strp_done(&tsk->strp);
+
 		sockfd_put(tsk->socket);
 		tsk->socket = NULL;
 	}
+
+	cancel_work_sync(&tsk->recv_work);
+	cancel_work_sync(&tsk->send_work);
 
 	kfree(tsk->iv_send);
 
@@ -1951,6 +1967,7 @@ static void tls_sock_destruct(struct sock *sk)
 
 	crypto_free_aead(tsk->aead_recv);
 
+	skb_queue_purge(&tsk->rx_hold_queue);
 	skb_queue_purge(&sk->sk_receive_queue);
 }
 


### PR DESCRIPTION
Need to implement 'read_sock' and 'peek_len', everything else should just work.

peek_len explictly tracks unread bytes.

read_sock is very similar to tcp_read_sock, but doesn't need to deal with acks.